### PR TITLE
Fixed mem leak

### DIFF
--- a/MCSMKeychainItem.m
+++ b/MCSMKeychainItem.m
@@ -465,7 +465,7 @@
    
     }
 
-    
+    [results release];
     
     return genericKeychainItem;
 }


### PR DESCRIPTION
Fixed a memory leak that Instruments reported in `genericKeychainItemForService` when `SecItemCopyMatching` is being called.
